### PR TITLE
chore: set rust version to 1.89 because we have let chains now

### DIFF
--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -45,7 +45,7 @@ jobs:
       - name: Install Rust
         uses: dtolnay/rust-toolchain@stable
         with:
-          toolchain: stable
+          toolchain: 1.89
 
       - name: Install cargo tools
         uses: taiki-e/install-action@v2

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,7 +2,7 @@
 name = "examen-tools"
 version = "0.0.1"
 edition = "2021"
-rust-version = "1.84.0"
+rust-version = "1.89.0"
 description = "A set of tools to ease testing across different languages and frameworks using neovim."
 repository = "https://github.com/Ydot19/examen-tools"
 license = "MIT"

--- a/README.md
+++ b/README.md
@@ -1,9 +1,10 @@
 # TT - Testing Tools
 
-Purpose: Set of utilities to be used in overseer tasks to accelerate the Edit-Build-Test Cycle
+Purpose: Set of utilities to be used in overseer tasks to accelerate the
+Edit-Build-Test Cycle
 
 ## Setup
 
 Requires a minimum of Rust 1.89.
 
-For using the correct version of rust, see `mise.toml`
+This project recommends using [mise](https://mise.jdx.dev/lang/rust.html).

--- a/README.md
+++ b/README.md
@@ -1,3 +1,9 @@
 # TT - Testing Tools
 
 Purpose: Set of utilities to be used in overseer tasks to accelerate the Edit-Build-Test Cycle
+
+## Setup
+
+Requires a minimum of Rust 1.89.
+
+For using the correct version of rust, see `mise.toml`


### PR DESCRIPTION
## Related Issue  
<!-- Attached the related issue -->

### Additional Context

<!-- (Optional) add additional context about pull-request about. -->
Bump rust version to 1.89 to enable usage of let chains

### How is it implemented

<!-- How is this change implemented -->

### Check the related fields

- [ ] Documentation <!-- Updates the documentation and related to this repository -->
- [ ] Feature <!-- Adds a net new capability -->
- [ ] Enhancement <!-- updates an existing feature and adds to it -->
- [ ] Test <!-- updates or adds new tests -->
- [x] Chore
<!--
updates the way this repository is run
- ci
- issue templates
- license
- deployment
- release
-->
