### PR TITLE
[lib/framework] refactor: move some queries to own directory

### DIFF
--- a/lib/framework/golang/treesitter/queries/build_tags.rs
+++ b/lib/framework/golang/treesitter/queries/build_tags.rs
@@ -1,10 +1,10 @@
 pub(crate) fn query() -> String {
-    let query_pattern = r#"
+    let pattern = r#"
             [[((source_file 
               (comment) @build_tags
                 (package_clause
                   (package_identifier) @package_name
                 ))(#any_contains? @build_tags "//go:build" "//+build"))]]
             "#;
-    query_pattern.to_string()
+    pattern.to_string()
 }

--- a/lib/framework/golang/treesitter/queries/gotest_file_test_methods.rs
+++ b/lib/framework/golang/treesitter/queries/gotest_file_test_methods.rs
@@ -1,0 +1,17 @@
+pub(crate) fn query() -> String {
+    let res = r#"
+            [[((function_declaration 
+                    name: (identifier) @test_name
+                    parameters: (parameter_list
+                        (parameter_declaration
+                                 name: (identifier)
+                                 type: (pointer_type
+                                     (qualified_type
+                                      package: (package_identifier) @_param_package
+                                      name: (type_identifier) @_param_name))))
+                     ) @testfunc
+                  (#contains? @test_name "Test"))]]
+            "#;
+
+    res.to_string()
+}

--- a/lib/framework/golang/treesitter/queries/gotest_subtest_in_loop_named_fields.rs
+++ b/lib/framework/golang/treesitter/queries/gotest_subtest_in_loop_named_fields.rs
@@ -1,0 +1,95 @@
+// query
+//
+// Given subtests defined in the loop of within gotest,
+//
+// This query will find all the subtests given the struct for each
+// test explicitly states each field name.
+//
+// Example:
+// func TestTableTest(t *testing.T) {
+// 	for _, tt := range []struct {
+// 		description string
+// 		a           int
+// 		b           int
+// 		expected    int
+// 	}{
+// 		{
+// 			description: "base case",
+// 			a:           0,
+// 			b:           3,
+// 			expected:    3,
+// 		},
+// 		{
+// 			description: "case 1",
+// 			a:           1,
+// 			b:           3,
+// 			expected:    4,
+// 		},
+// 	} {
+// 		t.Run(tt.description, func(t *testing.T) {
+// 			actual := sample_add(tt.a, tt.b)
+// 			assert.Equal(t, tt.expected, actual)
+// 		})
+// 	}
+// }
+//
+// This will find the following subtests:
+// - "base case"
+// - "case 1"
+pub(crate) fn query() -> String {
+    let res = r#"
+        [[
+          ((for_statement
+            (range_clause
+              left: (expression_list
+                (identifier)
+                (identifier) @test.loop.case.variable
+              )
+              right: (composite_literal
+                type: (slice_type
+                  element: (struct_type
+                    (field_declaration_list
+                      (field_declaration
+                      	name: (field_identifier) @test.case.definition.field
+                        type: (type_identifier) @test.case.definition.field.type (#eq? @test.case.definition.field.type "string")
+                      )
+                    )
+                  ) @test.case.type
+                )
+                body: (literal_value
+                  (literal_element
+                    (literal_value
+                      (keyed_element
+                        (literal_element
+                          (identifier)
+                        )  @test.case.field.name (#eq? @test.case.field.name @test.case.definition.field)
+                        (literal_element
+                          (interpreted_string_literal) @test.case.field.value
+                        )
+                      )
+                    ) @test.case
+                  )
+                )
+              )
+            )
+            body: (block
+              (expression_statement
+                (call_expression
+                  function: (selector_expression
+                    operand: (identifier) @test.loop.test
+                    field: (field_identifier) @test.loop.test.method (#eq? @test.loop.test.method "Run")
+                  )
+                  arguments: (argument_list
+                    (selector_expression
+                      operand: (identifier) @test.loop.test.variable (#eq? @test.loop.test.variable @test.loop.case.variable)
+                      field: (field_identifier) @test.loop.test.variable.field (#eq? @test.loop.test.variable.field @test.case.definition.field)
+                    ) 
+                  )
+                )
+              )
+            )
+          ))
+        ]]"#;
+
+    res.to_string()
+}

--- a/lib/framework/golang/treesitter/queries/gotest_subtest_in_loop_unnamed_fields.rs
+++ b/lib/framework/golang/treesitter/queries/gotest_subtest_in_loop_unnamed_fields.rs
@@ -39,56 +39,64 @@
 pub(crate) fn query() -> String {
     let res = r#"
         [[
-          ((for_statement
-            (range_clause
-              left: (expression_list
-                (identifier)
-                (identifier) @test.loop.case.variable
-              )
-              right: (composite_literal
-                type: (slice_type
-                  element: (struct_type
-                    (field_declaration_list
-                      (field_declaration
-                      	name: (field_identifier) @test.case.definition.field
-                        type: (type_identifier) @test.case.definition.field.type (#eq? @test.case.definition.field.type "string")
-                      )
-                    )
-                  ) @test.case.type
-                )
-                body: (literal_value
-                  (literal_element
-                    (literal_value
-                      (keyed_element
-                        (literal_element
-                          (identifier)
-                        )  @test.case.field.name (#eq? @test.case.field.name @test.case.definition.field)
-                        (literal_element
-                          (interpreted_string_literal) @test.case.field.value
+              ;; query for function name
+              ((function_declaration 
+                                name: (identifier) @_test.parent.name
+                                parameters: (parameter_list
+                                    (parameter_declaration
+                                             name: (identifier) @_test.parent.var
+                                             type: (pointer_type
+                                                 (qualified_type
+                                                  package: (package_identifier) @_test.param_package
+                                                  name: (type_identifier) @_test.param_name))))
+                                 ) @testfunc
+                              (#contains? @_test.parent.name "Test"))
+              ;; query for list table tests (wrapped in loop)
+              (for_statement
+                (range_clause
+                  left: (expression_list
+                    (identifier)
+                    (identifier) @test.loop.case.variable
+                  )
+                  right: (composite_literal
+                    type: (slice_type
+                      element: (struct_type
+                        (field_declaration_list
+                          (field_declaration
+                            name: (field_identifier) @test.case.definition.field
+                            type: (type_identifier) @test.case.definition.field.type (#eq? @test.case.definition.field.type "string")
+                          )
                         )
                       )
-                    ) @test.case
+                    )
+                    body: (literal_value
+                      (literal_element
+                        (literal_value
+                          (literal_element
+                            (interpreted_string_literal) @test.case.field.value
+                          )
+                        ) 
+                      ) @test.case
+                    )
+                  )
+                )
+                body: (block
+                  (expression_statement
+                    (call_expression
+                      function: (selector_expression
+                        operand: (identifier) @test.loop.test
+                        field: (field_identifier) @test.loop.test.method (#eq? @test.loop.test.method "Run")
+                      )
+                      arguments: (argument_list
+                        (selector_expression
+                          operand: (identifier) @test.loop.test.variable (#eq? @test.loop.test.variable @test.loop.case.variable)
+                          field: (field_identifier) @test.loop.test.variable.field (#eq? @test.loop.test.variable.field @test.case.definition.field)
+                        )
+                      )
+                    )
                   )
                 )
               )
-            )
-            body: (block
-              (expression_statement
-                (call_expression
-                  function: (selector_expression
-                    operand: (identifier) @test.loop.test
-                    field: (field_identifier) @test.loop.test.method (#eq? @test.loop.test.method "Run")
-                  )
-                  arguments: (argument_list
-                    (selector_expression
-                      operand: (identifier) @test.loop.test.variable (#eq? @test.loop.test.variable @test.loop.case.variable)
-                      field: (field_identifier) @test.loop.test.variable.field (#eq? @test.loop.test.variable.field @test.case.definition.field)
-                    ) 
-                  )
-                )
-              )
-            )
-          ))
         ]]"#;
 
     res.to_string()

--- a/lib/framework/golang/treesitter/queries/gotest_subtest_in_loop_unnamed_fields.rs
+++ b/lib/framework/golang/treesitter/queries/gotest_subtest_in_loop_unnamed_fields.rs
@@ -1,0 +1,95 @@
+// query
+//
+// Given subtests defined in the loop of within gotest,
+//
+// This query will find all the subtests given the struct for each
+// test implicity defines struct fields.
+//
+// Example:
+// func TestTableTest(t *testing.T) {
+// 	for _, tt := range []struct {
+// 		description string
+// 		a           int
+// 		b           int
+// 		expected    int
+// 	}{
+// 		{
+// 			"base case",
+// 			0,
+// 			3,
+// 			3,
+// 		},
+// 		{
+// 			"case 1",
+// 			1,
+// 			3,
+// 			4,
+// 		},
+// 	} {
+// 		t.Run(tt.description, func(t *testing.T) {
+// 			actual := sample_add(tt.a, tt.b)
+// 			assert.Equal(t, tt.expected, actual)
+// 		})
+// 	}
+// }
+//
+// This will find the following subtests:
+// - "base case"
+// - "case 1"
+pub(crate) fn query() -> String {
+    let res = r#"
+        [[
+          ((for_statement
+            (range_clause
+              left: (expression_list
+                (identifier)
+                (identifier) @test.loop.case.variable
+              )
+              right: (composite_literal
+                type: (slice_type
+                  element: (struct_type
+                    (field_declaration_list
+                      (field_declaration
+                      	name: (field_identifier) @test.case.definition.field
+                        type: (type_identifier) @test.case.definition.field.type (#eq? @test.case.definition.field.type "string")
+                      )
+                    )
+                  ) @test.case.type
+                )
+                body: (literal_value
+                  (literal_element
+                    (literal_value
+                      (keyed_element
+                        (literal_element
+                          (identifier)
+                        )  @test.case.field.name (#eq? @test.case.field.name @test.case.definition.field)
+                        (literal_element
+                          (interpreted_string_literal) @test.case.field.value
+                        )
+                      )
+                    ) @test.case
+                  )
+                )
+              )
+            )
+            body: (block
+              (expression_statement
+                (call_expression
+                  function: (selector_expression
+                    operand: (identifier) @test.loop.test
+                    field: (field_identifier) @test.loop.test.method (#eq? @test.loop.test.method "Run")
+                  )
+                  arguments: (argument_list
+                    (selector_expression
+                      operand: (identifier) @test.loop.test.variable (#eq? @test.loop.test.variable @test.loop.case.variable)
+                      field: (field_identifier) @test.loop.test.variable.field (#eq? @test.loop.test.variable.field @test.case.definition.field)
+                    ) 
+                  )
+                )
+              )
+            )
+          ))
+        ]]"#;
+
+    res.to_string()
+}

--- a/lib/framework/golang/treesitter/queries/gotest_subtest_in_loop_unnamed_fields_struct_predefined.rs
+++ b/lib/framework/golang/treesitter/queries/gotest_subtest_in_loop_unnamed_fields_struct_predefined.rs
@@ -1,0 +1,98 @@
+// query
+//
+// Given subtests defined in the loop of within gotest,
+//
+// This query will find all the subtests given the struct for each
+// test implicity defines struct fields.
+//
+// Example:
+// func TestTableTest(t *testing.T) {
+// 	type Scenario struct {
+// 		description string
+// 		a           int
+// 		b           int
+// 		expected    int
+// 	}
+// 	for _, tt := range []Scenario{
+// 		{
+// 			"base case",
+// 			0,
+// 			3,
+// 			3,
+// 		},
+// 		{
+// 			"case 1",
+// 			1,
+// 			3,
+// 			4,
+// 		},
+// 	} {
+// 		t.Run(tt.description, func(t *testing.T) {
+// 			actual := sample_add(tt.a, tt.b)
+// 			assert.Equal(t, tt.expected, actual)
+// 		})
+// 	}
+// }
+//
+// This will find the following subtests:
+// - "base case"
+// - "case 1"
+pub(crate) fn query() -> String {
+    let res = r#"
+            [[
+              (((type_declaration
+                  (type_spec
+                      name: (type_identifier) @test.case.variable.name
+                        type: (struct_type 
+                          (field_declaration_list
+                              (field_declaration
+                                name: (field_identifier) @test.case.definition.field
+                                type: (type_identifier) @test.case.definition.field.type (#eq? @test.case.definition.field.type "string")
+                          )
+                        )
+                    ) @test.case.type
+                  )
+                ) 
+                (for_statement
+                    (range_clause
+                      left: (expression_list
+                        (identifier)
+                        (identifier) @test.loop.case.variable
+                      )
+                      right: (composite_literal
+                          type: (slice_type
+                          element: (type_identifier) @test.loop.case.variable.type (#eq? @test.loop.case.variable.type @test.case.variable.name)
+                        )
+                        body: (literal_value
+                          (literal_element
+                            (literal_value
+                              (literal_element
+                                (interpreted_string_literal) @test.case.field.value
+                              )
+                            )
+                          ) @test.case
+                        )
+                      )
+                    )
+                    body: (block
+                      (expression_statement
+                        (call_expression
+                          function: (selector_expression
+                            operand: (identifier) @test.loop.test
+                            field: (field_identifier) @test.loop.test.method (#eq? @test.loop.test.method "Run")
+                          )
+                          arguments: (argument_list
+                            (selector_expression
+                                operand: (identifier) @test.loop.test.variable (#eq? @test.loop.case.variable @test.loop.test.variable)
+                                field: (field_identifier) @test.loop.test.variable.field (#eq? @test.case.definition.field @test.loop.test.variable.field)
+                            )
+                          )
+                        )
+                      )
+                    )
+                  )
+              ))
+            ]]"#;
+
+    res.to_string()
+}

--- a/lib/framework/golang/treesitter/queries/gotest_subtest_string_literal.rs
+++ b/lib/framework/golang/treesitter/queries/gotest_subtest_string_literal.rs
@@ -1,0 +1,60 @@
+// query
+//
+// Returns a treesitter query that locates subsets as string literals
+//
+// Example:
+// package golang
+// import (
+//   "testing"
+//
+//   "github.com/stretchr/testify/assert"
+// )
+//
+// func sample_add(a, b int) int {
+//   return a + b
+// }
+//
+// func TestSample(t *testing.T) {
+//     t.Run("case_a", func(t *testing.T){
+//       assert.Equal(t, 1, sample_add(1, 0))
+//     })
+//     t.Run("case_b", func(t *testing.T){
+//       assert.Equal(t, 2, sample_add(1, 2))
+//     })
+// }
+//
+// If the position is on TestSample, it will find `case_a` and `cas_b` as subtests
+pub(crate) fn query() -> String {
+    let res = r#"
+            [[
+              ;; string literal sub test
+              (((expression_statement
+                  (call_expression
+                      function: (selector_expression
+                          operand: (identifier) @testing
+                            field: (field_identifier) @testing.method (#eq? @testing.method "Run")
+                        )
+                        arguments: (argument_list
+                          (interpreted_string_literal) @test.case.name.value
+                            (func_literal
+                              parameters: (parameter_list
+                                  (parameter_declaration
+                                      name: (identifier)
+                                        type: (pointer_type
+                                          (qualified_type
+                                            package: (package_identifier) @test.case.package  
+                                              name: (type_identifier) @test.case.package.param 
+                        )	
+                      )
+                                    )
+                                )
+                            )
+                        )
+                    )
+                ) @test.case
+              ))
+            ]]
+        "#;
+
+    res.to_string()
+}

--- a/lib/framework/golang/treesitter/queries/mod.rs
+++ b/lib/framework/golang/treesitter/queries/mod.rs
@@ -1,1 +1,6 @@
-pub mod build_tags;
+pub(crate) mod build_tags;
+pub(crate) mod gotest_file_test_methods;
+pub(crate) mod gotest_subtest_in_loop_named_fields;
+pub(crate) mod gotest_subtest_in_loop_unnamed_fields;
+pub(crate) mod gotest_subtest_in_loop_unnamed_fields_struct_predefined;
+pub(crate) mod gotest_subtest_string_literal;


### PR DESCRIPTION
Moves 4 separate queries out of the core implementation for the gotest
framework runner

## Related Issue  
<!-- Attached the related issue -->

### Additional Context

<!-- (Optional) add additional context about pull-request about. -->

### How is it implemented

<!-- How is this change implemented -->

### Check the related fields

- [ ] Documentation <!-- Updates the documentation and related to this repository -->
- [ ] Feature <!-- Adds a net new capability -->
- [ ] Enhancement <!-- updates an existing feature and adds to it -->
- [ ] Test <!-- updates or adds new tests -->
- [ ] Chore
<!--
updates the way this repository is run
- ci
- issue templates
- license
- deployment
- release
-->
