### PR TITLE
enhance: add go test file detection logic

### DIFF
--- a/lib/framework/golang/gotest.rs
+++ b/lib/framework/golang/gotest.rs
@@ -10,6 +10,7 @@ use crate::core::{
     traits::{Framework, FrameworkProvider},
     types::CapabilityDetails,
 };
+use crate::framework::golang::operations::detect_gotest_file;
 use crate::framework::golang::operations::gotest_get_file_tests;
 use crate::framework::golang::operations::gotest_get_subtests;
 use crate::framework::golang::operations::gotest_get_test;
@@ -65,6 +66,14 @@ impl FrameworkProvider for GotestProvider {
 
 impl Framework for GotestProvider {
     fn detect(&self, target: &Target) -> bool {
+        let tree = parse_tree::op::execute(target.buffer.content);
+        if tree.is_err() {
+            return false;
+        }
+        let tree = tree.unwrap();
+        if !detect_gotest_file::op::execute(tree.root_node(), target.buffer.content) {
+            return false;
+        }
         if target.category != self.capability() {
             return false;
         }

--- a/lib/framework/golang/operations/detect_gotest_file.rs
+++ b/lib/framework/golang/operations/detect_gotest_file.rs
@@ -1,0 +1,137 @@
+pub(crate) mod op {
+    use tree_sitter::{Language, Node, Query, QueryCursor};
+
+    use crate::framework::golang::treesitter::{
+        constants, package_in_import_list, package_in_single_import,
+    };
+
+    pub fn execute(root: Node, content: &str) -> bool {
+        let single_import_query_pattern =
+            package_in_single_import::query().replace(constants::PACKAGE, "testing");
+        let list_import_query_pattern =
+            package_in_import_list::query().replace(constants::PACKAGE, "testing");
+
+        let query = Query::new(
+            &Language::new(tree_sitter_go::LANGUAGE),
+            single_import_query_pattern.as_str(),
+        );
+
+        if let Result::Ok(q) = query {
+            let mut cursor = QueryCursor::new();
+            let query_matches = cursor.matches(&q, root, content.as_bytes());
+            if query_matches.count().gt(&0) {
+                return true;
+            }
+        }
+        let query = Query::new(
+            &Language::new(tree_sitter_go::LANGUAGE),
+            list_import_query_pattern.as_str(),
+        );
+        if let Result::Ok(q) = query {
+            let mut cursor = QueryCursor::new();
+            let query_matches = cursor.matches(&q, root, content.as_bytes());
+            if query_matches.count().gt(&0) {
+                return true;
+            }
+        }
+
+        false
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use googletest::{
+        assert_that, gtest,
+        prelude::{anything, eq, ok},
+    };
+
+    use crate::framework::golang::operations::parse_tree;
+
+    use super::op;
+
+    #[gtest]
+    fn testing_package_found() {
+        let content: &str = r#"
+        package golang
+        import "testing"
+
+        func sample_add(a, b int) int {
+          return a + b
+        }
+        "#;
+        let tree = parse_tree::op::execute(content);
+        assert_that!(tree, ok(anything()));
+        let tree = tree.unwrap();
+        let root = tree.root_node();
+        // act
+        let res = op::execute(root, content);
+        // assert
+        assert_that!(res, eq(true))
+    }
+    #[gtest]
+    fn testing_package_not_found() {
+        let content: &str = r#"
+        package golang
+        import "context"
+
+        func sample_add(a, b int) int {
+          return a + b
+        }
+        "#;
+        let tree = parse_tree::op::execute(content);
+        assert_that!(tree, ok(anything()));
+        let tree = tree.unwrap();
+        let root = tree.root_node();
+        // act
+        let res = op::execute(root, content);
+        // assert
+        assert_that!(res, eq(false))
+    }
+    #[gtest]
+    fn testing_package_found_in_import_list() {
+        let content: &str = r#"
+        package golang
+        import (
+          "testing"
+
+          "context"
+        )
+
+        func sample_add(a, b int) int {
+          return a + b
+        }
+        "#;
+        let tree = parse_tree::op::execute(content);
+        assert_that!(tree, ok(anything()));
+        let tree = tree.unwrap();
+        let root = tree.root_node();
+        // act
+        let res = op::execute(root, content);
+        // assert
+        assert_that!(res, eq(true))
+    }
+    #[gtest]
+    fn testing_package_not_found_in_import_list() {
+        let content: &str = r#"
+        package golang
+        import (
+          "fmt"
+
+          "context"
+        )
+
+        func sample_add(a, b int) int {
+          return a + b
+        }
+        "#;
+        let tree = parse_tree::op::execute(content);
+        assert_that!(tree, ok(anything()));
+        let tree = tree.unwrap();
+        let root = tree.root_node();
+        // act
+        let res = op::execute(root, content);
+        // assert
+        assert_that!(res, eq(false))
+    }
+}

--- a/lib/framework/golang/operations/detect_gotest_file.rs
+++ b/lib/framework/golang/operations/detect_gotest_file.rs
@@ -27,7 +27,9 @@ pub(crate) mod op {
             &Language::new(tree_sitter_go::LANGUAGE),
             list_import_query_pattern.as_str(),
         );
+        println!("part 1");
         if let Result::Ok(q) = query {
+            print!("hello");
             let mut cursor = QueryCursor::new();
             let query_matches = cursor.matches(&q, root, content.as_bytes());
             if query_matches.count().gt(&0) {

--- a/lib/framework/golang/operations/mod.rs
+++ b/lib/framework/golang/operations/mod.rs
@@ -1,3 +1,4 @@
+pub(crate) mod detect_gotest_file;
 pub(crate) mod get_build_tags;
 pub(crate) mod gotest_get_file_tests;
 pub(crate) mod gotest_get_subtests;

--- a/lib/framework/golang/treesitter/constants.rs
+++ b/lib/framework/golang/treesitter/constants.rs
@@ -1,0 +1,1 @@
+pub(crate) const PACKAGE: &str = "$PACKAGE";

--- a/lib/framework/golang/treesitter/mod.rs
+++ b/lib/framework/golang/treesitter/mod.rs
@@ -1,4 +1,5 @@
 pub(crate) mod build_tags;
+pub(crate) mod constants;
 pub(crate) mod gotest_file_test_methods;
 pub(crate) mod gotest_subtest_in_loop_named_fields;
 pub(crate) mod gotest_subtest_in_loop_named_fields_struct_predfined;
@@ -8,3 +9,5 @@ pub(crate) mod gotest_subtest_out_of_loop_named_fields;
 pub(crate) mod gotest_subtest_out_of_loop_unnamed_fields;
 pub(crate) mod gotest_subtest_string_literal;
 pub(crate) mod gotest_test_function;
+pub(crate) mod package_in_import_list;
+pub(crate) mod package_in_single_import;

--- a/lib/framework/golang/treesitter/package_in_import_list.rs
+++ b/lib/framework/golang/treesitter/package_in_import_list.rs
@@ -1,0 +1,43 @@
+use crate::framework::golang::treesitter::constants;
+
+// query
+//
+// Give a list of packages in a import list, find a given package by replacing
+// $PACKAGE in the query query
+//
+// Example:
+// import (
+// 	"testing"
+// 	"github.com/stretchr/testify/assert"
+// )
+//
+//
+// and the query is
+// [[
+// 	;; imported packages
+// 	(import_declaration
+//     	(import_spec_list
+//         	(import_spec
+//             	path: (interpreted_string_literal) @import.path (#eq? @import.path "\"testing\"")
+//          ))
+//     )
+// ]]
+//
+// by replacing $PACKAGE with "testing", the query will find a match
+pub(crate) fn query() -> String {
+    let res = format!(
+        r#"
+        [[
+	          (import_declaration
+    	          (import_spec_list
+        	          (import_spec
+            	          path: (interpreted_string_literal) @import.path (#eq? @import.path "\{}\"")
+                ))
+        )
+        ]]
+    "#,
+        constants::PACKAGE
+    );
+
+    res.to_string()
+}

--- a/lib/framework/golang/treesitter/package_in_import_list.rs
+++ b/lib/framework/golang/treesitter/package_in_import_list.rs
@@ -31,7 +31,7 @@ pub(crate) fn query() -> String {
 	          (import_declaration
     	          (import_spec_list
         	          (import_spec
-            	          path: (interpreted_string_literal) @import.path (#eq? @import.path "\{}\"")
+            	          path: (interpreted_string_literal) @import.path (#eq? @import.path "\"{}\"")
                 ))
         )
         ]]

--- a/lib/framework/golang/treesitter/package_in_single_import.rs
+++ b/lib/framework/golang/treesitter/package_in_single_import.rs
@@ -1,0 +1,36 @@
+use crate::framework::golang::treesitter::constants;
+
+// query
+//
+// Given a single import go file, this query checks if that single import is
+// the package be queried.
+//
+// Example:
+// import "testing"
+//
+// and the query is
+// [[
+// 	(import_declaration
+//       (import_spec
+//           path: (interpreted_string_literal) @import.path (#eq? @import.path "\"$PACKAGE\"")
+//      )
+// )
+// ]]
+//
+// by replacing $PACKAGE with "testing", the query will find a match
+pub(crate) fn query() -> String {
+    let res = format!(
+        r#"
+        [[
+          (import_declaration
+                  (import_spec
+                      path: (interpreted_string_literal) @import.path (#eq? @import.path "\"{}\"")
+                 )
+            )
+        ]]
+    "#,
+        constants::PACKAGE
+    );
+
+    res.to_string()
+}


### PR DESCRIPTION
### Description

Adds Go test file detection to identify test files by checking for the "testing" package import.

### Checklist
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] Style
- [x] Test
- [ ] Documentation
- [ ] Chore